### PR TITLE
Fix tests at least with Stack

### DIFF
--- a/pcg-random.cabal
+++ b/pcg-random.cabal
@@ -75,4 +75,5 @@ test-suite doctests
   hs-source-dirs:   test
   build-depends:
     base,
-    doctest
+    doctest,
+    pcg-random

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -1,12 +1,17 @@
+import System.Environment (getEnvironment)
 import Test.DocTest
 
-main = doctest
-  [ "src/System/Random/PCG.hs"
-  , "src/System/Random/PCG/Class.hs"
-  , "src/System/Random/PCG/Pure.hs"
-  , "src/System/Random/PCG/Fast.hs"
-  , "src/System/Random/PCG/Single.hs"
-  , "dist/build/c/pcg-advance-64.o"
-  , "dist/build/c/pcg-output-64.o"
-  , "dist/build/c/pcg-rngs-64.o"
-  ]
+main = do
+  env <- getEnvironment
+  let dist = case lookup "HASKELL_DIST_DIR" env of
+               Nothing -> "dist"
+               Just x -> x
+  doctest [ "src/System/Random/PCG.hs"
+          , "src/System/Random/PCG/Class.hs"
+          , "src/System/Random/PCG/Pure.hs"
+          , "src/System/Random/PCG/Fast.hs"
+          , "src/System/Random/PCG/Single.hs"
+          , dist ++ "/build/c/pcg-advance-64.o"
+          , dist ++ "/build/c/pcg-output-64.o"
+          , dist ++ "/build/c/pcg-rngs-64.o"
+          ]


### PR DESCRIPTION
This makes tests succeed on Stack, unfortunately I couldn't find a how to solve it for `cabal new-test` because new Cabal commands use a bit different directory structure and the most curious thing is that 2nd invocation of `cabal new-test` succeeds after failing on the 1st try.