### PR TITLE
Cabal doctest

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,6 @@
-import Distribution.Simple
-main = defaultMain
+module Main where
+
+import Distribution.Extra.Doctest (defaultMainWithDoctests)
+
+main :: IO ()
+main = defaultMainWithDoctests "doctests"

--- a/pcg-random.cabal
+++ b/pcg-random.cabal
@@ -25,8 +25,14 @@ Homepage:            http://github.com/cchalmers/pcg-random
 Bug-reports:         http://github.com/cchalmers/pcg-random/issues
 copyright:           (c) 2014-2015. Christopher Chalmers <c.chalmers@me.com>
 category:            System
-build-type:          Simple
+build-type:          Custom
 cabal-version:       >=1.10
+
+custom-setup
+ setup-depends:
+   base >= 4 && <5,
+   Cabal,
+   cabal-doctest >= 1 && <1.1
 
 source-repository head
   type:     git
@@ -75,4 +81,5 @@ test-suite doctests
   hs-source-dirs:   test
   build-depends:
     base,
-    doctest
+    doctest,
+    pcg-random

--- a/src/System/Random/PCG/Fast/Pure.hs
+++ b/src/System/Random/PCG/Fast/Pure.hs
@@ -168,7 +168,7 @@ restore f = do
 -- | Generate a new seed using single 'Word64'.
 --
 --   >>> initFrozen 0
---   FrozenGen 1
+--   F 1
 initFrozen :: Word64 -> FrozenGen
 initFrozen w = F (w .|. 1)
 
@@ -183,7 +183,7 @@ create = restore seed
 -- | Initialize a generator a single word.
 --
 --   >>> initialize 0 >>= save
---   FrozenGen 1
+--   F 1
 initialize :: PrimMonad m => Word64 -> m (Gen (PrimState m))
 initialize a = restore (initFrozen a)
 

--- a/test/doctest.hs
+++ b/test/doctest.hs
@@ -1,12 +1,7 @@
-import Test.DocTest
+module Main where
 
-main = doctest
-  [ "src/System/Random/PCG.hs"
-  , "src/System/Random/PCG/Class.hs"
-  , "src/System/Random/PCG/Pure.hs"
-  , "src/System/Random/PCG/Fast.hs"
-  , "src/System/Random/PCG/Single.hs"
-  , "dist/build/c/pcg-advance-64.o"
-  , "dist/build/c/pcg-output-64.o"
-  , "dist/build/c/pcg-rngs-64.o"
-  ]
+import Build_doctests (flags, pkgs, module_sources)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = doctest $ flags ++ pkgs ++ module_sources


### PR DESCRIPTION
This PR makes this package have working tests for 2 versions of Cabal commands and for Stack as well.
Also I've fixed doctests which were failing (fixed output and not the constructor definition, I'm not 100% which was the correct way).
Fixes #7 